### PR TITLE
ember-cli-google-analytics: Expand and document `gtag.configure()` options

### DIFF
--- a/packages/ember-cli-google-analytics/README.md
+++ b/packages/ember-cli-google-analytics/README.md
@@ -55,6 +55,21 @@ export default class ApplicationRoute extends Route {
 }
 ```
 
+The `gtag.configure()` method optionally accepts an `options` object with the following properties:
+
+| Property | Type | Desciption |
+| --- | --- | --- |
+| `measurementId` | `string` | When set, overrides the `measurementId` defined in your app's `config/environment` file. |
+| `forceEnable` | `boolean` | If `true`, allows `gtag.configure()` to run in the `development` and `test` environments. (By default, `gtag.configure()` doesn't work unless the environment is `production`.) |
+
+Example using both properties:
+```javascript
+await this.gtag.configure({
+  measurementId: 'G-XXXXXXXXXX',
+  forceEnable: true,
+});
+```
+
 ### Sending custom events to Google Analytics
 
 You can easily send custom events to Google Analytics by injecting the `gtag` service, and

--- a/packages/ember-cli-google-analytics/README.md
+++ b/packages/ember-cli-google-analytics/README.md
@@ -55,18 +55,20 @@ export default class ApplicationRoute extends Route {
 }
 ```
 
-The `gtag.configure()` method optionally accepts an `options` object with the following properties:
+The `gtag.configure()` method optionally accepts an `options` object with any of the following properties:
 
 | Property | Type | Desciption |
 | --- | --- | --- |
 | `measurementId` | `string` | When set, overrides the `measurementId` defined in your app's `config/environment` file. |
 | `forceEnable` | `boolean` | If `true`, allows `gtag.configure()` to run in the `development` and `test` environments. (By default, `gtag.configure()` doesn't work unless the environment is `production`.) |
+| `debugMode` | `boolean` | If `true`, configures `gtag` to run in debug mode, which can be helpful for development. |
 
 Example using both properties:
 ```javascript
 await this.gtag.configure({
   measurementId: 'G-XXXXXXXXXX',
   forceEnable: true,
+  debugMode: true,
 });
 ```
 

--- a/packages/ember-cli-google-analytics/addon/services/gtag.js
+++ b/packages/ember-cli-google-analytics/addon/services/gtag.js
@@ -15,6 +15,7 @@ export default class GtagService extends Service {
     const {
       measurementId = options.measurementId,
       forceEnable = options.forceEnable,
+      debugMode = options.debugMode,
     } = get (ENV, 'ember-cli-google.analytics') || {};
 
     if (ENV.environment === 'production' || forceEnable) {
@@ -29,7 +30,7 @@ export default class GtagService extends Service {
       await this.script.load(`https://www.googletagmanager.com/gtag/js?id=${measurementId}`);
 
       this.push('js', new Date());
-      this.push('config', measurementId);
+      this.push('config', measurementId, { debug_mode: !!debugMode });
     }
   }
 


### PR DESCRIPTION
Hi there, I just have a small addition to the docs detailing the options you can pass to `gtag.configure()`. I based them off of my understanding from reading the `gtag` service code, so please feel free to edit them if needed.

I think this is a good contribution because I personally needed to dig through the source code to find `forceEnable` to check that `gtag.configure()` was working correctly. Putting it in the README makes that a little easier.