### PR TITLE
Bug fix: `gtag.event()` syntax

### DIFF
--- a/packages/ember-cli-google-analytics/addon/services/gtag.js
+++ b/packages/ember-cli-google-analytics/addon/services/gtag.js
@@ -41,6 +41,6 @@ export default class GtagService extends Service {
   }
 
   event(name, params) {
-    this.push({ event: name, ...params });
+    this.push('event', name, { ...params });
   }
 }


### PR DESCRIPTION
This PR fixes a bug where the `gtag` service's `event()` method sends the event to the `window.dataLayer` with incorrect syntax. This bug prevents GA4 from receiving any event sent via `gtag.event()`.

I noticed this bug first on my own, then saw it corroborated by @romgere in #8. [This comment in that thread](https://developers.google.com/tag-platform/gtagjs/reference#event) matches my experience, and my proposed solution.

Here's the syntax that should be used to send events, via the [API documentation](https://developers.google.com/tag-platform/gtagjs/reference#event.):
```javascript
gtag('event', '<event_name>', {<event_params>});
```

If accepted, this 1-line change will close #8 and make it possible to send events via this package. Best of all, the change doesn't break existing calls to `gtag.event()`, it just makes those calls actually work.

Thanks for making this available! I hope this contribution helps.